### PR TITLE
Corrected output folder path creation on Windows

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ dev() {
     mkdir -p output
     docker run --rm --gpus=all --entrypoint=sh \
         -v huggingface:/home/huggingface/.cache/huggingface \
-        -v "$PWD"/output:/home/huggingface/output \
+        -v /"$PWD"/output:/home/huggingface/output \
         -it "$CWD"
 }
 
@@ -25,7 +25,7 @@ run() {
     mkdir -p output
     docker run --rm --gpus=all \
         -v huggingface:/home/huggingface/.cache/huggingface \
-        -v "$PWD"/output:/home/huggingface/output \
+        -v /"$PWD"/output:/home/huggingface/output \
         "$CWD" "$@"
 }
 


### PR DESCRIPTION
## Background
On Windows, when using **.\build.sh run**, two folders are created instead of one:
- output
- output;C

The first is created cause of the **mkdir** command and is expected.
The latter is created cause of improper path conversion when creating a bind mount.

Since the python file is saving the images to the **output** folder where as **output;C** is mounted to the container, no images generated are visible on Windows.

## Reference
[Docker mounted volume adds ;C to end of windows path when translating from linux style path](https://stackoverflow.com/questions/50608301/docker-mounted-volume-adds-c-to-end-of-windows-path-when-translating-from-linux)