### PR TITLE
Add attention slicing

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ are implemented for compatibility:
 
 Other options:
 
+* `--attention-slicing`: use less memory at the expense of inference speed
 * `--half`: use float16 tensors instead of float32 (default float32)
 * `--skip`: skip safety checker
 * `--token [TOKEN]`: specify a Huggingface user access token at the command line

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -14,7 +14,18 @@ def skip_safety_checker(images, *args, **kwargs):
 
 
 def stable_diffusion(
-    prompt, samples, iters, height, width, steps, scale, seed, half, skip, token
+    prompt,
+    samples,
+    iters,
+    height,
+    width,
+    steps,
+    scale,
+    seed,
+    half,
+    skip,
+    do_slice,
+    token,
 ):
     model_name = "CompVis/stable-diffusion-v1-4"
     device = "cuda"
@@ -29,6 +40,9 @@ def stable_diffusion(
 
     if skip:
         pipe.safety_checker = skip_safety_checker
+
+    if do_slice:
+        pipe.enable_attention_slicing()
 
     print("loaded models after:", iso_date_time())
 
@@ -101,6 +115,14 @@ def main():
         "--ddim_steps", type=int, nargs="?", default=50, help="Number of sampling steps"
     )
     parser.add_argument(
+        "--attention-slicing",
+        type=bool,
+        nargs="?",
+        const=True,
+        default=False,
+        help="Use less memory at the expense of inference speed",
+    )
+    parser.add_argument(
         "--half",
         type=bool,
         nargs="?",
@@ -143,6 +165,7 @@ def main():
         args.seed,
         args.half,
         args.skip,
+        args.attention_slicing,
         args.token,
     )
 


### PR DESCRIPTION
The latest release of [diffusers](https://github.com/huggingface/diffusers/releases/tag/v0.3.0) has added attention slicing which decreases GPU memory use at the cost of inference speed. Add the `--attention-slicing` option to use this feature:

```sh
./build.sh run --attention-slicing --half --prompt 'abstract art'
```