### PR TITLE
Upgrade to diffusers v0.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM tensorflow/tensorflow:2.10.0-gpu
 
-RUN pip install diffusers pillow torch transformers \
+COPY requirements.txt /
+
+RUN pip install -r requirements.txt \
   --extra-index-url https://download.pytorch.org/whl/cu116
 
 RUN useradd -m huggingface

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-diffusers==0.3.0
+diffusers==0.4.1
 torch==1.12.1+cu116
 transformers==4.22.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+diffusers==0.3.0
+torch==1.12.1+cu116
+transformers==4.22.2


### PR DESCRIPTION
A new version of the `diffusers` library was released:

- Pin dependencies to make the build reproducible and track releases
- Upgrade to [`diffusers` v0.4.1](https://github.com/huggingface/diffusers/releases/tag/v0.4.1)
