### PR TITLE
Remove CUDA stubs to prevent errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM tensorflow/tensorflow:2.10.0-gpu
 
+RUN rm -rf /usr/local/cuda/lib64/stubs
+
 COPY requirements.txt /
 
 RUN pip install -r requirements.txt \


### PR DESCRIPTION
In certain configurations the CUDA stubs are prioritized over the real CUDA shared libraries which causes unexpected errors. Remove the stubs to ensure only the real shared libraries are used.

Resolves #22 , resolves #13 