### PR TITLE
Make Stable Diffusion model configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Other options:
 * `--attention-slicing`: use less memory at the expense of inference speed
 (default is no attention slicing)
 * `--half`: use float16 tensors instead of float32 (default float32)
+* `--model`: the model used to render images (default is `CompVis/stable-diffusion-v1-4`)
 * `--skip`: skip safety checker (default is the safety checker is on)
 * `--token [TOKEN]`: specify a Huggingface user access token at the command line
 instead of reading it from a file (default is a file)

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -14,6 +14,7 @@ def skip_safety_checker(images, *args, **kwargs):
 
 
 def stable_diffusion(
+    model,
     prompt,
     samples,
     iters,
@@ -27,7 +28,6 @@ def stable_diffusion(
     do_slice,
     token,
 ):
-    model_name = "CompVis/stable-diffusion-v1-4"
     device = "cuda"
 
     dtype, rev = (torch.float16, "fp16") if half else (torch.float32, "main")
@@ -35,7 +35,7 @@ def stable_diffusion(
     print("load pipeline start:", iso_date_time())
 
     pipe = StableDiffusionPipeline.from_pretrained(
-        model_name, torch_dtype=dtype, revision=rev, use_auth_token=token
+        model, torch_dtype=dtype, revision=rev, use_auth_token=token
     ).to(device)
 
     if skip:
@@ -131,6 +131,13 @@ def main():
         help="Use float16 (half-sized) tensors instead of float32",
     )
     parser.add_argument(
+        "--model",
+        type=str,
+        nargs="?",
+        default="CompVis/stable-diffusion-v1-4",
+        help="The model used to render images",
+    )
+    parser.add_argument(
         "--skip",
         type=bool,
         nargs="?",
@@ -155,6 +162,7 @@ def main():
             args.token = f.read().replace("\n", "")
 
     stable_diffusion(
+        args.model,
         args.prompt,
         args.n_samples,
         args.n_iter,


### PR DESCRIPTION
The RunwayML team have released their own version of [stable diffusion v1.5](https://huggingface.co/runwayml/stable-diffusion-v1-5). Add the `--model` option to support it:

```sh
./build.sh run --model 'runwayml/stable-diffusion-v1-5' --prompt 'abstract art'
```

You need to first get access by accepting the terms on https://huggingface.co/runwayml/stable-diffusion-v1-5