### PR TITLE
Update transformers to v4.24.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ USER huggingface
 
 WORKDIR /home/huggingface
 
+ENV USE_TORCH=1
+
 RUN mkdir -p /home/huggingface/.cache/huggingface \
   && mkdir -p /home/huggingface/output
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 diffusers==0.6.0
 torch==1.12.1+cu116
-transformers==4.23.1
+transformers==4.24.0


### PR DESCRIPTION
Fix an issue where tensorflow could be used instead of pytorch, and update transformers to [v4.24.0](https://github.com/huggingface/transformers/releases/tag/v4.24.0).