### PR TITLE
Upgrade torch to 1.13.0 and cuda to 11.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN rm -rf /usr/local/cuda/lib64/stubs
 COPY requirements.txt /
 
 RUN pip install -r requirements.txt \
-  --extra-index-url https://download.pytorch.org/whl/cu116
+  --extra-index-url https://download.pytorch.org/whl/cu117
 
 RUN useradd -m huggingface
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 diffusers==0.6.0
-torch==1.12.1+cu116
+torch==1.13.0+cu117
 transformers==4.24.0


### PR DESCRIPTION
A new stable version of Pytorch was [recently released](https://pytorch.org/get-started/locally/) which also uses a more recent version of CUDA.
