### PR TITLE
Upgrade diffusers to 0.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-diffusers==0.6.0
+diffusers[torch]==0.7.0
 torch==1.13.0+cu117
 transformers==4.24.0


### PR DESCRIPTION
A new version of the [`diffusers`](https://github.com/huggingface/diffusers/releases/tag/v0.7.0) library was released which adds a few useful features including long prompts and seed resizing.

`diffusers` also now depends on the `accelerate` library which requires updating `requirements.txt` with the new library syntax.