### PR TITLE
Add negative prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Other options:
 (default is no attention slicing)
 * `--half`: use float16 tensors instead of float32 (default float32)
 * `--model`: the model used to render images (default is `CompVis/stable-diffusion-v1-4`)
+* `--negative-prompt`: the prompt to not render into an image (default `None`)
 * `--skip`: skip safety checker (default is the safety checker is on)
 * `--token [TOKEN]`: specify a Huggingface user access token at the command line
 instead of reading it from a file (default is a file)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ and increase image creation speed
 * Use `--half` to decrease memory use but slightly decrease image quality
 * Use `--attention-slicing` to decrease memory use but also decrease image
 creation speed
+* Decrease the number of samples and increase the number of iterations with
+`--n_samples` and `--n_iter` to decrease overall memory use
 * Skip the safety checker with `--skip` to run less code
 
 ```sh

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -42,7 +42,7 @@ def stable_diffusion_pipeline(model, half, skip, do_slice, token):
 
 
 def stable_diffusion_inference(
-    pipeline, prompt, samples, iters, height, width, steps, scale, seed
+    pipeline, prompt, neg_prompt, samples, iters, height, width, steps, scale, seed
 ):
     if seed == 0:
         seed = torch.random.seed()
@@ -54,6 +54,7 @@ def stable_diffusion_inference(
         with autocast(cuda_device()):
             result = pipeline(
                 prompt,
+                negative_prompt=neg_prompt,
                 height=height,
                 width=width,
                 num_images_per_prompt=samples,
@@ -140,6 +141,12 @@ def main():
         help="The model used to render images",
     )
     parser.add_argument(
+        "--negative-prompt",
+        type=str,
+        nargs="?",
+        help="The prompt to not render into an image",
+    )
+    parser.add_argument(
         "--skip",
         type=bool,
         nargs="?",
@@ -163,6 +170,7 @@ def main():
     stable_diffusion_inference(
         pipeline,
         args.prompt,
+        args.negative_prompt,
         args.n_samples,
         args.n_iter,
         args.H,

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -53,9 +53,10 @@ def stable_diffusion_inference(
     for j in range(iters):
         with autocast(cuda_device()):
             result = pipeline(
-                [prompt] * samples,
+                prompt,
                 height=height,
                 width=width,
+                num_images_per_prompt=samples,
                 num_inference_steps=steps,
                 guidance_scale=scale,
                 generator=generator,


### PR DESCRIPTION
Adds negative prompts which are prompts that should be excluded from the image. For example, you can generate bouquets of roses that are **not** red using:

```sh
./build.sh run --prompt 'bouquet of roses' --negative-prompt 'red roses'
```

Also refactor the code to use `num_images_per_prompt` for efficiency and to avoid bugs with negative prompts.
