### PR TITLE
Add ONNX pipeline for CPU inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ container.
 
 ## Before you start
 
-The pipeline uses the full model and weights which requires 8GB+ of GPU RAM. It
-should take a few seconds to create one image. On smaller GPUs you may need to
-modify some of the parameters, see the [Examples](#examples) section for more
-details.
+By default, the pipeline uses the full model and weights which requires a CUDA
+capable GPU with 8GB+ of VRAM. It should take a few seconds to create one image.
+On less powerful GPUs you may need to modify some of the options; see the
+[Examples](#examples) section for more details. If you lack a suitable GPU you
+can set the option `--device cpu` instead.
 
 Since it uses the official model, you will need to create a [user access token](https://huggingface.co/docs/hub/security-tokens)
 in your [Huggingface account](https://huggingface.co/settings/tokens). Save the
@@ -92,6 +93,8 @@ Other options:
 
 * `--attention-slicing`: use less memory at the expense of inference speed
 (default is no attention slicing)
+* `--device [DEVICE]`: the cpu or cuda device to use to render images (default
+`cuda`)
 * `--half`: use float16 tensors instead of float32 (default `float32`)
 * `--image [IMAGE]`: the input image to use for image-to-image diffusion
 (default `None`)

--- a/build.sh
+++ b/build.sh
@@ -29,9 +29,9 @@ run() {
 }
 
 tests() {
-    run "abstract art"
+    run --H 512 --W 640 "abstract art"
     run --model "runwayml/stable-diffusion-v1-5" \
-        --H 512 --W 512 --n_samples 2 --n_iter 2 --seed 42 \
+        --n_samples 2 --n_iter 2 --seed 42 \
         --scale 7.5 --ddim_steps 80 --attention-slicing \
         --half --skip --negative-prompt "red roses" \
         --prompt "bouquet of roses"

--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,7 @@ run() {
 
 tests() {
     run --H 512 --W 640 "abstract art"
+    run --device cpu "abstract art"
     run --model "runwayml/stable-diffusion-v1-5" \
         --n_samples 2 --n_iter 2 --seed 42 \
         --scale 7.5 --ddim_steps 80 --attention-slicing \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 diffusers[torch]==0.7.2
+onnxruntime==1.13.1
 torch==1.13.0+cu117
 transformers==4.24.0


### PR DESCRIPTION
Adds ONNX as a dependency for CPU inference which can be used on systems that lack a suitable GPU. Refactor the codebase to add new features more easily.

Resolves #10 , resolves #35 