### PR TITLE
Do not set GPU argument if using CPU pipeline

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,16 @@ set -eu
 
 CWD=$(basename "$PWD")
 
+set_gpu_arg() {
+    while [ "$#" -gt 0 ]; do
+        if [ "$1" = "--device" ] && [ "$2" = "cpu" ]; then
+            GPU_ARG=""
+        fi
+        shift
+    done
+    GPU_ARG="--gpus=all"
+}
+
 build() {
     docker build . --tag "$CWD"
 }
@@ -21,7 +31,8 @@ dev() {
 }
 
 run() {
-    docker run --rm --gpus=all \
+    set_gpu_arg "$@"
+    docker run --rm ${GPU_ARG} \
         -v huggingface:/home/huggingface/.cache/huggingface \
         -v "$PWD"/input:/home/huggingface/input \
         -v "$PWD"/output:/home/huggingface/output \


### PR DESCRIPTION
Do not set `--gpus=all` if using the CPU pipeline as it causes errors in Docker if there is no suitable GPU available.