### PR TITLE
Fix error with ONNX pipeline when using `--skip`

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,10 @@ MSYS_NO_PATHCONV=1 ./build.sh run --half --prompt 'abstract art'
 
 ### Model
 
-The model and other files are cached in a volume called `huggingface`.
+The model and other files are cached in a volume called `huggingface`. The
+models are stored in `<volume>/diffusers/<model>/snapshots/<githash>/unet/<weights>`.
+Checkpoint files (`ckpt`s) are unofficial versions of the official models, and
+so these are not part of the official release.
 
 ### Images
 

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -24,10 +24,6 @@ def load_image(path):
     return image
 
 
-def skip_safety_checker(images, *args, **kwargs):
-    return images, False
-
-
 def stable_diffusion_pipeline(p):
     p.dtype = torch.float16 if p.half else torch.float32
 
@@ -75,7 +71,7 @@ def stable_diffusion_pipeline(p):
     ).to(p.device)
 
     if p.skip:
-        pipeline.safety_checker = skip_safety_checker
+        pipeline.safety_checker = None
 
     if p.attention_slicing:
         pipeline.enable_attention_slicing()


### PR DESCRIPTION
Add details on where model outputs are stored and fix error with `--skip` option when using ONNX pipeline.

Resolves #30, resolves #33