### PR TITLE
Fixes for diffusers 0.10.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ set_gpu_arg() {
     while [ "$#" -gt 0 ]; do
         if [ "$1" = "--device" ] && [ "$2" = "cpu" ]; then
             GPU_ARG=""
+            return
         fi
         shift
     done

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -3,7 +3,6 @@ import argparse, datetime, inspect, os
 import numpy as np
 import torch
 from PIL import Image
-from torch import autocast
 from diffusers import (
     OnnxStableDiffusionPipeline,
     OnnxStableDiffusionInpaintPipeline,
@@ -104,8 +103,7 @@ def stable_diffusion_pipeline(p):
 def stable_diffusion_inference(p):
     prefix = p.prompt.replace(" ", "_")[:170]
     for j in range(p.n_iter):
-        with autocast(p.device):
-            result = p.pipeline(**remove_unused_args(p))
+        result = p.pipeline(**remove_unused_args(p))
 
         for i, img in enumerate(result.images):
             idx = j * p.n_samples + i + 1

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -26,17 +26,17 @@ def load_image(path):
 def remove_unused_args(p):
     params = inspect.signature(p.pipeline).parameters.keys()
     args = {
-        'prompt': p.prompt,
-        'negative_prompt': p.negative_prompt,
-        'image': p.image,
-        'mask_image': p.mask,
-        'height': p.H,
-        'width': p.W,
-        'num_images_per_prompt': p.n_samples,
-        'num_inference_steps': p.ddim_steps,
-        'guidance_scale': p.scale,
-        'strength': p.strength,
-        'generator': p.generator,
+        "prompt": p.prompt,
+        "negative_prompt": p.negative_prompt,
+        "image": p.image,
+        "mask_image": p.mask,
+        "height": p.H,
+        "width": p.W,
+        "num_images_per_prompt": p.n_samples,
+        "num_inference_steps": p.ddim_steps,
+        "guidance_scale": p.scale,
+        "strength": p.strength,
+        "generator": p.generator,
     }
     return {p: args[p] for p in params if p in args}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-diffusers[torch]==0.10.0
+diffusers[torch]==0.10.1
 onnxruntime==1.13.1
 torch==1.13.0+cu117
 transformers==4.25.1


### PR DESCRIPTION
Implement several fixes for diffusers 0.10.0:

- Remove use of autocast as it is no longer recommended in any pipeline
- Remove unused arguments from pipeline due to stricter pipeline checks
- Return after setting `GPU_ARG` to fix issue with cpu pipelines and resolve #41 
- Bump diffusers to 0.10.1