### PR TITLE
Add memory efficient attention using xformers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,7 @@ tests() {
     run --device cpu --image "${TEST_IMAGE}" --strength 0.6 "abstract art"
     run --model "stabilityai/stable-diffusion-x4-upscaler" \
         --image "${TEST_IMAGE}" --half --attention-slicing \
+        --xformers-memory-efficient-attention \
         --prompt "An impressionist painting of a parakeet eating spaghetti in the desert"
     run --model "runwayml/stable-diffusion-v1-5" \
         --n_samples 2 --n_iter 2 --seed 42 \

--- a/build.sh
+++ b/build.sh
@@ -43,7 +43,7 @@ run() {
 tests() {
     TEST_IMAGE="An_impressionist_painting_of_a_parakeet_eating_spaghetti_in_the_desert_s1.png"
     cp "img/${TEST_IMAGE}" "input/${TEST_IMAGE}"
-    run --H 512 --W 640 "abstract art"
+    run --skip --H 512 --W 640 "abstract art"
     run --device cpu --image "${TEST_IMAGE}" --strength 0.6 "abstract art"
     run --model "stabilityai/stable-diffusion-x4-upscaler" \
         --image "${TEST_IMAGE}" --half --attention-slicing \

--- a/build.sh
+++ b/build.sh
@@ -45,6 +45,9 @@ tests() {
     cp "img/${TEST_IMAGE}" "input/${TEST_IMAGE}"
     run --H 512 --W 640 "abstract art"
     run --device cpu --image "${TEST_IMAGE}" --strength 0.6 "abstract art"
+    run --model "stabilityai/stable-diffusion-x4-upscaler" \
+        --image "${TEST_IMAGE}" --half --attention-slicing \
+        --prompt "An impressionist painting of a parakeet eating spaghetti in the desert"
     run --model "runwayml/stable-diffusion-v1-5" \
         --n_samples 2 --n_iter 2 --seed 42 \
         --scale 7.5 --ddim_steps 80 --attention-slicing \

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -97,6 +97,9 @@ def stable_diffusion_pipeline(p):
     if p.attention_slicing:
         pipeline.enable_attention_slicing()
 
+    if p.xformers_memory_efficient_attention:
+        pipeline.enable_xformers_memory_efficient_attention()
+
     p.pipeline = pipeline
 
     print("loaded models after:", iso_date_time(), flush=True)
@@ -226,6 +229,14 @@ def main():
     )
     parser.add_argument(
         "--token", type=str, nargs="?", help="Huggingface user access token"
+    )
+    parser.add_argument(
+        "--xformers-memory-efficient-attention",
+        type=bool,
+        nargs="?",
+        const=True,
+        default=False,
+        help="Use less memory but require the xformers library",
     )
 
     args = parser.parse_args()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ diffusers[torch]==0.10.2
 onnxruntime==1.13.1
 torch==1.13.0+cu117
 transformers==4.25.1
+xformers==0.0.16rc379


### PR DESCRIPTION
Adds the [xformers](https://github.com/facebookresearch/xformers) library to dramatically decrease memory use during image upscaling:

```sh
./build run --model "stabilityai/stable-diffusion-x4-upscaler" \
  --half --attention-slicing --xformers-memory-efficient-attention \
  --image image.png --prompt "A detailed description of the image"
```
