### PR TITLE
Add other schedulers

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Other options:
 `CompVis/stable-diffusion-v1-4`)
 * `--negative-prompt [NEGATIVE_PROMPT]`: the prompt to not render into an image
 (default `None`)
+* `--scheduler [SCHEDULER]`: the scheduler used to denoise the image (default
+`None`)
 * `--skip`: skip safety checker (default is the safety checker is on)
 * `--strength [STRENGTH]`: diffusion strength to apply to the input image
 (default 0.75)

--- a/build.sh
+++ b/build.sh
@@ -55,6 +55,7 @@ tests() {
         --prompt "An impressionist painting of a parakeet eating spaghetti in the desert"
     run --model "runwayml/stable-diffusion-v1-5" \
         --n_samples 2 --n_iter 2 --seed 42 \
+        --scheduler HeunDiscreteScheduler \
         --scale 7.5 --ddim_steps 80 --attention-slicing \
         --half --skip --negative-prompt "red roses" \
         --prompt "bouquet of roses"

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -11,6 +11,7 @@ from diffusers import (
     StableDiffusionImg2ImgPipeline,
     StableDiffusionInpaintPipeline,
     StableDiffusionUpscalePipeline,
+    schedulers,
 )
 
 
@@ -90,6 +91,10 @@ def stable_diffusion_pipeline(p):
         revision=p.revision,
         use_auth_token=p.token,
     ).to(p.device)
+
+    if p.scheduler is not None:
+        scheduler = getattr(schedulers, p.scheduler)
+        pipeline.scheduler = scheduler.from_config(pipeline.scheduler.config)
 
     if p.skip:
         pipeline.safety_checker = None
@@ -212,6 +217,12 @@ def main():
         type=str,
         nargs="?",
         help="The prompt to not render into an image",
+    )
+    parser.add_argument(
+        "--scheduler",
+        type=str,
+        nargs="?",
+        help="The scheduler used to denoise the image",
     )
     parser.add_argument(
         "--skip",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 diffusers[torch]==0.11.1
 onnxruntime==1.13.1
 safetensors==0.2.6
-torch==1.13.0+cu117
+torch==1.13.1+cu117
 transformers==4.25.1
-xformers==0.0.16rc379
+xformers==0.0.16rc396


### PR DESCRIPTION
Allow different schedulers to be used with the `--scheduler` option, including `k_huen`, `k_lms`, etc. See [https://huggingface.co/docs/diffusers/api/schedulers/overview](https://huggingface.co/docs/diffusers/api/schedulers/overview) for a complete list of available schedulers. For example, to use `k_huen`, use the corresponding `diffusers` scheduler named `HeunDiscreteScheduler`:

```sh
./build.sh run --scheduler HeunDiscreteScheduler --prompt 'abstract art'
```
