### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ safetensors==0.2.6
 torch==1.13.1+cu117
 transformers==4.25.1
 xformers==0.0.16rc396
+numpy==1.23.4


### PR DESCRIPTION
Latest numpy version (1.24) lacks required 'float' attribute, therefore leading to a failure when trying to generate a txt2img output