### PR TITLE
Bump safetensors and xformers and add numpy 1.23.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 diffusers[torch]==0.11.1
 numpy==1.23.5
 onnxruntime==1.13.1
-safetensors==0.2.6
+safetensors==0.2.7
 torch==1.13.1+cu117
 transformers==4.25.1
-xformers==0.0.16rc396
+xformers==0.0.16rc403

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 diffusers[torch]==0.11.1
+numpy==1.23.5
 onnxruntime==1.13.1
 safetensors==0.2.6
 torch==1.13.1+cu117


### PR DESCRIPTION
Bump existing libraries and fix errors with deprecated `float` types by temporarily requiring an older version of `numpy`:

- Temporarily add `numpy` 1.23.5
- Bump `safetensors` to 0.2.7
- Bump unstable `xformers` to 0.0.16rc403

Resolves #51, resolves #52