### PR TITLE
Describe how to pull Stable Diffusion Docker image from GHCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ when building the container. The token content should begin with `hf_...`
 The pipeline is managed using a single [`build.sh`](build.sh) script. You must
 build the image before it can be run.
 
+Alternately, you can pull the latest version of `stable-diffusion-docker` from
+the Github Container Registry using `./build.sh pull`, but you will need to use
+the `--token` command line option to specify a valid [user access token](#huggingface-token)
+when using [`./build run`](#run).
+
 ## Build
 
 Make sure your [user access token](#huggingface-token) is saved in a file called

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ container.
 
 ## Before you start
 
+### Minimum specs
+
 By default, the pipeline uses the full model and weights which requires a CUDA
 capable GPU with 8GB+ of VRAM. It should take a few seconds to create one image.
 On less powerful GPUs you may need to modify some of the options; see the
@@ -28,10 +30,12 @@ can set the option `--device cpu` instead. If you are using Docker Desktop and
 the container is terminated you may need to give Docker more resources by
 increasing the CPU, memory, and swap in the Settings -> Resources section.
 
+### Huggingface token
+
 Since it uses the official model, you will need to create a [user access token](https://huggingface.co/docs/hub/security-tokens)
 in your [Huggingface account](https://huggingface.co/settings/tokens). Save the
 user access token in a file called `token.txt` and make sure it is available
-when building the container.
+when building the container. The token content should begin with `hf_...`
 
 ## Quickstart
 
@@ -40,8 +44,8 @@ build the image before it can be run.
 
 ## Build
 
-Make sure your [user access token](#before-you-start) is saved in a file called
-`token.txt`. The token content should begin with `hf_...`
+Make sure your [user access token](#huggingface-token) is saved in a file called
+`token.txt`.
 
 To build:
 

--- a/build.sh
+++ b/build.sh
@@ -31,6 +31,11 @@ dev() {
         -it "$CWD"
 }
 
+pull() {
+    docker pull ghcr.io/fboulnois/stable-diffusion-docker
+    docker tag ghcr.io/fboulnois/stable-diffusion-docker "$CWD"
+}
+
 run() {
     set_gpu_arg "$@"
     docker run --rm ${GPU_ARG} \
@@ -66,6 +71,7 @@ case ${1:-build} in
     build) build ;;
     clean) clean ;;
     dev) dev "$@" ;;
+    pull) pull ;;
     run) shift; run "$@" ;;
     test) tests ;;
     *) echo "$0: No command named '$1'" ;;


### PR DESCRIPTION
Add a section in the quickstart on how to pull the latest Stable Diffusion Docker image from the GitHub Container Registry instead of manually building the container. For example, to use the new `pull` build option:

```sh
./build pull
./build run --token ${HF_TOKEN} --prompt 'abstract art'
```