### PR TITLE
Set Github Container Registry as default

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
     inputs:
       version:
         required: true
-        default: 'latest'
         type: string
 env:
   SD_VERSION: ${{ github.event.inputs.version }}
@@ -31,5 +30,5 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/fboulnois/stable-diffusion-docker:latest
-            ghcr.io/fboulnois/stable-diffusion-docker:${{ env.SD_VERSION }}
+            ghcr.io/${{ GITHUB_REPOSITORY }}:latest
+            ghcr.io/${{ GITHUB_REPOSITORY }}:${{ env.SD_VERSION }}

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ when building the container. The token content should begin with `hf_...`
 
 ## Quickstart
 
-The pipeline is managed using a single [`build.sh`](build.sh) script. You must
-build the image before it can be run.
+The pipeline is managed using a single [`build.sh`](build.sh) script.
 
-Alternately, you can pull the latest version of `stable-diffusion-docker` from
-the Github Container Registry using `./build.sh pull`, but you will need to use
-the option `--token` to specify a valid [user access token](#huggingface-token)
+Pull the latest version of `stable-diffusion-docker` using `./build.sh pull`.
+You will need to use the option `--token` to specify a valid [user access token](#huggingface-token)
 when using [`./build run`](#run).
+
+Alternately, build the image locally before running it.
 
 ## Build
 

--- a/build.sh
+++ b/build.sh
@@ -32,8 +32,9 @@ dev() {
 }
 
 pull() {
-    docker pull ghcr.io/fboulnois/stable-diffusion-docker
-    docker tag ghcr.io/fboulnois/stable-diffusion-docker "$CWD"
+    GHCR="ghcr.io/fboulnois/stable-diffusion-docker"
+    docker pull "$GHCR"
+    docker tag "$GHCR" "$CWD"
 }
 
 run() {


### PR DESCRIPTION
Refactor container push and pull code to avoid hardcoding parameters and make pulling containers the default way to use `stable-diffusion-docker`.