### PR TITLE
Automatically publish new versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,15 @@
 name: Publish
 on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
-      version:
+      git_tag:
         required: true
         type: string
 env:
-  SD_VERSION: ${{ github.event.inputs.version }}
+  GIT_TAG: ${{ github.event.inputs.git_tag || github.ref_name }}
 jobs:
   publish:
     runs-on: ubuntu-22.04
@@ -14,7 +17,10 @@ jobs:
       - name: Checkout specified tag
         uses: actions/checkout@v3
         with:
-          ref: v${{ env.SD_VERSION }}
+          ref: ${{ env.GIT_TAG }}
+      - name: Create version tag for Docker image
+        run: |
+          echo "BUILD_VERSION=$(echo ${GIT_TAG} | sed 's/^v//')" >> $GITHUB_ENV
       - name: Create empty token file
         run: |
           touch token.txt
@@ -31,4 +37,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ env.SD_VERSION }}
+            ghcr.io/${{ github.repository }}:${{ env.BUILD_VERSION }}


### PR DESCRIPTION
When a new tag is pushed, automatically publish a new version of `stable-diffusion-docker` to Github Container Registry.