### PR TITLE
Update unstable xformers to 0.0.16rc425

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ onnxruntime==1.13.1
 safetensors==0.2.7
 torch==1.13.1+cu117
 transformers==4.25.1
-xformers==0.0.16rc403
+xformers==0.0.16rc425


### PR DESCRIPTION
Update `xformers` library to 0.0.16rc425 to avoid missing dependencies.