### PR TITLE
Update diffusers to 0.12.0

### DIFF
--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import argparse, datetime, inspect, os
+import argparse, datetime, inspect, os, warnings
 import numpy as np
 import torch
 from PIL import Image
@@ -85,12 +85,14 @@ def stable_diffusion_pipeline(p):
 
     print("load pipeline start:", iso_date_time(), flush=True)
 
-    pipeline = p.diffuser.from_pretrained(
-        p.model,
-        torch_dtype=p.dtype,
-        revision=p.revision,
-        use_auth_token=p.token,
-    ).to(p.device)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        pipeline = p.diffuser.from_pretrained(
+            p.model,
+            torch_dtype=p.dtype,
+            revision=p.revision,
+            use_auth_token=p.token,
+        ).to(p.device)
 
     if p.scheduler is not None:
         scheduler = getattr(schedulers, p.scheduler)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-diffusers[torch]==0.11.1
-numpy==1.23.5
+diffusers[torch]==0.12.0
 onnxruntime==1.13.1
-safetensors==0.2.7
+safetensors==0.2.8
 torch==1.13.1+cu117
-transformers==4.25.1
+transformers==4.26.0
 xformers==0.0.16rc425


### PR DESCRIPTION
Update diffusers to [0.12.0](https://github.com/huggingface/diffusers/releases/tag/v0.12.0) and dependencies:

- Update transformers to [4.26.0](https://github.com/huggingface/transformers/releases/tag/v4.26.0)
- Update safetensors to [0.2.8](https://pypi.org/project/safetensors/0.2.8)
- Temporarily suppress [CLIPFeatureExtractor](https://github.com/huggingface/transformers/blob/v4.26.0/src/transformers/models/clip/feature_extraction_clip.py) deprecation warning