### PR TITLE
Rename old img2img options

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,8 @@ instead of reading it from a file (default is a file)
 * `--xformers-memory-efficient-attention`: use less memory but require the
 xformers library (default is that xformers is not required)
 
-As some of the original [`txt2img.py`](https://github.com/CompVis/stable-diffusion/blob/main/scripts/txt2img.py)
-options are hard to remember and `stable-diffusion-docker` supports newer
-pipelines, features, and models, the original `txt2img` options have been
-renamed for easy-of-use and compatibility:
+Some of the original `txt2img.py` options [have been renamed](https://github.com/fboulnois/stable-diffusion-docker/issues/49)
+for easy-of-use and compatibility with other pipelines:
 
 | txt2img | stable-diffusion-docker |
 |---------|-------------------------|

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ First, copy an image to the `input` folder. Next, to run:
 
 ```sh
 ./build.sh run --model 'stabilityai/stable-diffusion-x4-upscaler' \
-  --image image.png 'A detailed description of the image'
+  --image image.png 'Andromeda galaxy in a bottle'
 ```
 
 ### Diffusion Inpainting (`inpaint`)
@@ -176,7 +176,7 @@ Options can be combined:
 ./build.sh run --scale 7.0 --seed 42 'abstract art'
 ```
 
-On systems with <8GB of GPU RAM, you can try mixing and matching options:
+On systems without enough GPU VRAM, you can try mixing and matching options:
 
 * Make images smaller than 512x512 using `--height` and `--width` to decrease
 memory use and increase image creation speed

--- a/README.md
+++ b/README.md
@@ -109,11 +109,15 @@ mask will be diffused and black areas will be kept untouched. Next, to run:
 The following are the most common options:
 
 * `--prompt [PROMPT]`: the prompt to render into an image
+* `--model [MODEL]`: the model used to render images (default is
+`CompVis/stable-diffusion-v1-4`)
 * `--height [HEIGHT]`: image height in pixels (default 512, must be divisible by 64)
 * `--width [WIDTH]`: image width in pixels (default 512, must be divisible by 64)
 * `--iters [ITERS]`: number of times to run pipeline (default 1)
 * `--samples [SAMPLES]`: number of images to create per run (default 1)
 * `--scale [SCALE]`: unconditional guidance scale (default 7.5)
+* `--scheduler [SCHEDULER]`: override the scheduler used to denoise the image
+(default `None`)
 * `--seed [SEED]`: RNG seed for repeatability (default is a random seed)
 * `--steps [STEPS]`: number of sampling steps (default 50)
 
@@ -128,11 +132,7 @@ Other options:
 (default `None`)
 * `--mask [MASK]`: the input mask to use for diffusion inpainting (default
 `None`)
-* `--model [MODEL]`: the model used to render images (default is
-`CompVis/stable-diffusion-v1-4`)
 * `--negative-prompt [NEGATIVE_PROMPT]`: the prompt to not render into an image
-(default `None`)
-* `--scheduler [SCHEDULER]`: override the scheduler used to denoise the image
 (default `None`)
 * `--skip`: skip safety checker (default is the safety checker is on)
 * `--strength [STRENGTH]`: diffusion strength to apply to the input image
@@ -142,10 +142,10 @@ instead of reading it from a file (default is a file)
 * `--xformers-memory-efficient-attention`: use less memory but require the
 xformers library (default is that xformers is not required)
 
-As the original [`txt2img.py`](https://github.com/CompVis/stable-diffusion/blob/main/scripts/txt2img.py)
-script is deprecated and `stable-diffusion-docker` implements newer features
-like `img2img` and `inpaint`, the original `txt2img` options have been renamed
-for easy-of-use and compatibility:
+As some of the original [`txt2img.py`](https://github.com/CompVis/stable-diffusion/blob/main/scripts/txt2img.py)
+options are hard to remember and `stable-diffusion-docker` supports newer
+pipelines, features, and models, the original `txt2img` options have been
+renamed for easy-of-use and compatibility:
 
 | txt2img | stable-diffusion-docker |
 |---------|-------------------------|

--- a/README.md
+++ b/README.md
@@ -176,6 +176,22 @@ Options can be combined:
 ./build.sh run --scale 7.0 --seed 42 'abstract art'
 ```
 
+Many popular models are supported out-of-the-box:
+
+| Model Name | Option using `--model` |
+|------------|------------------------|
+| [Stable Diffusion 1.4](https://huggingface.co/CompVis/stable-diffusion-v1-4) | `'CompVis/stable-diffusion-v1-4'` |
+| [Stable Diffusion 1.5](https://huggingface.co/runwayml/stable-diffusion-v1-5) | `'runwayml/stable-diffusion-v1-5'` |
+| [Stable Diffusion 2.0](https://huggingface.co/stabilityai/stable-diffusion-2) | `'stabilityai/stable-diffusion-2'` |
+| [Stable Diffusion 2.1](https://huggingface.co/stabilityai/stable-diffusion-2-1) | `'stabilityai/stable-diffusion-2-1'` |
+| [OpenJourney 1.0](https://huggingface.co/prompthero/openjourney) | `'prompthero/openjourney'` |
+| [Dreamlike Diffusion 1.0](https://huggingface.co/dreamlike-art/dreamlike-diffusion-1.0) | `'dreamlike-art/dreamlike-diffusion-1.0'` |
+| [and more!](https://huggingface.co/models?other=stable-diffusion&sort=likes) | ... |
+
+```sh
+./build.sh run --model 'prompthero/openjourney' --prompt 'abstract art'
+```
+
 On systems without enough GPU VRAM, you can try mixing and matching options:
 
 * Make images smaller than 512x512 using `--height` and `--width` to decrease

--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ By default, the pipeline uses the full model and weights which requires a CUDA
 capable GPU with 8GB+ of VRAM. It should take a few seconds to create one image.
 On less powerful GPUs you may need to modify some of the options; see the
 [Examples](#examples) section for more details. If you lack a suitable GPU you
-can set the option `--device cpu` instead. If you are using Docker Desktop and
-the container is terminated you may need to give Docker more resources by
-increasing the CPU, memory, and swap in the Settings -> Resources section.
+can set the option `--device cpu` instead.
 
 ### Huggingface token
 
@@ -194,6 +192,8 @@ Many popular models are supported out-of-the-box:
 
 On systems without enough GPU VRAM, you can try mixing and matching options:
 
+* Give Docker Desktop more resources by increasing the CPU, memory, and swap in
+the Settings -> Resources section if the container is terminated
 * Make images smaller than 512x512 using `--height` and `--width` to decrease
 memory use and increase image creation speed
 * Use `--half` to decrease memory use but slightly decrease image quality

--- a/README.md
+++ b/README.md
@@ -106,17 +106,16 @@ mask will be diffused and black areas will be kept untouched. Next, to run:
 
 ### Options
 
-Some of the options from [`txt2img.py`](https://github.com/CompVis/stable-diffusion/blob/main/scripts/txt2img.py)
-are implemented for compatibility:
+The following are the most common options:
 
 * `--prompt [PROMPT]`: the prompt to render into an image
-* `--n_samples [N_SAMPLES]`: number of images to create per run (default 1)
-* `--n_iter [N_ITER]`: number of times to run pipeline (default 1)
-* `--H [H]`: image height in pixels (default 512, must be divisible by 64)
-* `--W [W]`: image width in pixels (default 512, must be divisible by 64)
+* `--height [HEIGHT]`: image height in pixels (default 512, must be divisible by 64)
+* `--width [WIDTH]`: image width in pixels (default 512, must be divisible by 64)
+* `--iters [ITERS]`: number of times to run pipeline (default 1)
+* `--samples [SAMPLES]`: number of images to create per run (default 1)
 * `--scale [SCALE]`: unconditional guidance scale (default 7.5)
 * `--seed [SEED]`: RNG seed for repeatability (default is a random seed)
-* `--ddim_steps [DDIM_STEPS]`: number of sampling steps (default 50)
+* `--steps [STEPS]`: number of sampling steps (default 50)
 
 Other options:
 
@@ -143,6 +142,19 @@ instead of reading it from a file (default is a file)
 * `--xformers-memory-efficient-attention`: use less memory but require the
 xformers library (default is that xformers is not required)
 
+As the original [`txt2img.py`](https://github.com/CompVis/stable-diffusion/blob/main/scripts/txt2img.py)
+script is deprecated and `stable-diffusion-docker` implements newer features
+like `img2img` and `inpaint`, the original `txt2img` options have been renamed
+for easy-of-use and compatibility:
+
+| txt2img | stable-diffusion-docker |
+|---------|-------------------------|
+| `--H` | `--height` |
+| `--W` | `--width` |
+| `--n_iter` | `--iters` |
+| `--n_samples` | `--samples` |
+| `--ddim_steps` | `--steps` |
+
 ## Examples
 
 These commands are both identical:
@@ -166,21 +178,21 @@ Options can be combined:
 
 On systems with <8GB of GPU RAM, you can try mixing and matching options:
 
-* Make images smaller than 512x512 using `--W` and `--H` to decrease memory use
-and increase image creation speed
+* Make images smaller than 512x512 using `--height` and `--width` to decrease
+memory use and increase image creation speed
 * Use `--half` to decrease memory use but slightly decrease image quality
 * Use `--attention-slicing` to decrease memory use but also decrease image
 creation speed
 * Use `--xformers-memory-efficient-attention` to decrease memory use if the
 pipeline and the hardware supports the option
 * Decrease the number of samples and increase the number of iterations with
-`--n_samples` and `--n_iter` to decrease overall memory use
+`--samples` and `--iters` to decrease overall memory use
 * Skip the safety checker with `--skip` to run less code
 
 ```sh
-./build.sh run --W 256 --H 256 --half \
+./build.sh run --height 256 --width 256 --half \
   --attention-slicing --xformers-memory-efficient-attention \
-  --n_samples 1 --n_iter 1 --skip --prompt 'abstract art'
+  --samples 1 --iters 1 --skip --prompt 'abstract art'
 ```
 
 On Windows, if you aren't using WSL2 and instead use MSYS, MinGW, or Git Bash,

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ mask will be diffused and black areas will be kept untouched. Next, to run:
   --image image.png --mask mask.png 'Andromeda galaxy in a bottle'
 ```
 
-### Options
+## Options
 
 The following are the most common options:
 

--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ tests() {
         --xformers-memory-efficient-attention \
         --prompt "An impressionist painting of a parakeet eating spaghetti in the desert"
     run --model "stabilityai/stable-diffusion-2-depth" \
-        --H 768 --W 768 \
+        --height 768 --width 768 \
         --image "${TEST_IMAGE}" --attention-slicing \
         --xformers-memory-efficient-attention \
         --negative-prompt "bad, ugly, deformed, malformed, mutated, bad anatomy" \

--- a/build.sh
+++ b/build.sh
@@ -47,8 +47,9 @@ run() {
 }
 
 tests() {
+    BASE_URL="https://raw.githubusercontent.com/fboulnois/repository-assets/main/assets/stable-diffusion-docker"
     TEST_IMAGE="An_impressionist_painting_of_a_parakeet_eating_spaghetti_in_the_desert_s1.png"
-    cp "img/${TEST_IMAGE}" "input/${TEST_IMAGE}"
+    curl -sL "${BASE_URL}/${TEST_IMAGE}" > "$PWD/input/${TEST_IMAGE}"
     run --skip --height 512 --width 640 "abstract art"
     run --device cpu --image "${TEST_IMAGE}" --strength 0.6 "abstract art"
     run --model "stabilityai/stable-diffusion-2" \

--- a/build.sh
+++ b/build.sh
@@ -49,12 +49,12 @@ run() {
 tests() {
     TEST_IMAGE="An_impressionist_painting_of_a_parakeet_eating_spaghetti_in_the_desert_s1.png"
     cp "img/${TEST_IMAGE}" "input/${TEST_IMAGE}"
-    run --skip --H 512 --W 640 "abstract art"
+    run --skip --height 512 --width 640 "abstract art"
     run --device cpu --image "${TEST_IMAGE}" --strength 0.6 "abstract art"
     run --model "stabilityai/stable-diffusion-2" \
-        --skip --H 768 --W 768 "abstract art"
+        --skip --height 768 --width 768 "abstract art"
     run --model "stabilityai/stable-diffusion-2-1" \
-        --skip --H 768 --W 768 "abstract art"
+        --skip --height 768 --width 768 "abstract art"
     run --model "stabilityai/stable-diffusion-x4-upscaler" \
         --image "${TEST_IMAGE}" --half --attention-slicing \
         --xformers-memory-efficient-attention \
@@ -66,9 +66,9 @@ tests() {
         --negative-prompt "bad, ugly, deformed, malformed, mutated, bad anatomy" \
         --prompt "a toucan"
     run --model "runwayml/stable-diffusion-v1-5" \
-        --n_samples 2 --n_iter 2 --seed 42 \
+        --samples 2 --iters 2 --seed 42 \
         --scheduler HeunDiscreteScheduler \
-        --scale 7.5 --ddim_steps 80 --attention-slicing \
+        --scale 7.5 --steps 80 --attention-slicing \
         --half --skip --negative-prompt "red roses" \
         --prompt "bouquet of roses"
 }

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -138,49 +138,6 @@ def stable_diffusion_inference(p):
 def main():
     parser = argparse.ArgumentParser(description="Create images from a text prompt.")
     parser.add_argument(
-        "prompt0",
-        metavar="PROMPT",
-        type=str,
-        nargs="?",
-        help="The prompt to render into an image",
-    )
-    parser.add_argument(
-        "--prompt", type=str, nargs="?", help="The prompt to render into an image"
-    )
-    parser.add_argument(
-        "--samples",
-        type=int,
-        nargs="?",
-        default=1,
-        help="Number of images to create per run",
-    )
-    parser.add_argument(
-        "--iters",
-        type=int,
-        nargs="?",
-        default=1,
-        help="Number of times to run pipeline",
-    )
-    parser.add_argument(
-        "--height", type=int, nargs="?", default=512, help="Image height in pixels"
-    )
-    parser.add_argument(
-        "--width", type=int, nargs="?", default=512, help="Image width in pixels"
-    )
-    parser.add_argument(
-        "--scale",
-        type=float,
-        nargs="?",
-        default=7.5,
-        help="Classifier free guidance scale",
-    )
-    parser.add_argument(
-        "--seed", type=int, nargs="?", default=0, help="RNG seed for repeatability"
-    )
-    parser.add_argument(
-        "--steps", type=int, nargs="?", default=50, help="Number of sampling steps"
-    )
-    parser.add_argument(
         "--attention-slicing",
         type=bool,
         nargs="?",
@@ -204,10 +161,20 @@ def main():
         help="Use float16 (half-sized) tensors instead of float32",
     )
     parser.add_argument(
+        "--height", type=int, nargs="?", default=512, help="Image height in pixels"
+    )
+    parser.add_argument(
         "--image",
         type=str,
         nargs="?",
         help="The input image to use for image-to-image diffusion",
+    )
+    parser.add_argument(
+        "--iters",
+        type=int,
+        nargs="?",
+        default=1,
+        help="Number of times to run pipeline",
     )
     parser.add_argument(
         "--mask",
@@ -229,10 +196,30 @@ def main():
         help="The prompt to not render into an image",
     )
     parser.add_argument(
+        "--prompt", type=str, nargs="?", help="The prompt to render into an image"
+    )
+    parser.add_argument(
+        "--samples",
+        type=int,
+        nargs="?",
+        default=1,
+        help="Number of images to create per run",
+    )
+    parser.add_argument(
+        "--scale",
+        type=float,
+        nargs="?",
+        default=7.5,
+        help="Classifier free guidance scale",
+    )
+    parser.add_argument(
         "--scheduler",
         type=str,
         nargs="?",
         help="Override the scheduler used to denoise the image",
+    )
+    parser.add_argument(
+        "--seed", type=int, nargs="?", default=0, help="RNG seed for repeatability"
     )
     parser.add_argument(
         "--skip",
@@ -241,6 +228,9 @@ def main():
         const=True,
         default=False,
         help="Skip the safety checker",
+    )
+    parser.add_argument(
+        "--steps", type=int, nargs="?", default=50, help="Number of sampling steps"
     )
     parser.add_argument(
         "--strength",
@@ -252,12 +242,22 @@ def main():
         "--token", type=str, nargs="?", help="Huggingface user access token"
     )
     parser.add_argument(
+        "--width", type=int, nargs="?", default=512, help="Image width in pixels"
+    )
+    parser.add_argument(
         "--xformers-memory-efficient-attention",
         type=bool,
         nargs="?",
         const=True,
         default=False,
         help="Use less memory but require the xformers library",
+    )
+    parser.add_argument(
+        "prompt0",
+        metavar="PROMPT",
+        type=str,
+        nargs="?",
+        help="The prompt to render into an image",
     )
 
     args = parser.parse_args()

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -33,10 +33,10 @@ def remove_unused_args(p):
         "negative_prompt": p.negative_prompt,
         "image": p.image,
         "mask_image": p.mask,
-        "height": p.H,
-        "width": p.W,
-        "num_images_per_prompt": p.n_samples,
-        "num_inference_steps": p.ddim_steps,
+        "height": p.height,
+        "width": p.width,
+        "num_images_per_prompt": p.samples,
+        "num_inference_steps": p.steps,
         "guidance_scale": p.scale,
         "strength": p.strength,
         "generator": p.generator,
@@ -124,12 +124,12 @@ def stable_diffusion_pipeline(p):
 
 def stable_diffusion_inference(p):
     prefix = p.prompt.replace(" ", "_")[:170]
-    for j in range(p.n_iter):
+    for j in range(p.iters):
         result = p.pipeline(**remove_unused_args(p))
 
         for i, img in enumerate(result.images):
-            idx = j * p.n_samples + i + 1
-            out = f"{prefix}__steps_{p.ddim_steps}__scale_{p.scale:.2f}__seed_{p.seed}__n_{idx}.png"
+            idx = j * p.samples + i + 1
+            out = f"{prefix}__steps_{p.steps}__scale_{p.scale:.2f}__seed_{p.seed}__n_{idx}.png"
             img.save(os.path.join("output", out))
 
     print("completed pipeline:", iso_date_time(), flush=True)
@@ -148,24 +148,24 @@ def main():
         "--prompt", type=str, nargs="?", help="The prompt to render into an image"
     )
     parser.add_argument(
-        "--n_samples",
+        "--samples",
         type=int,
         nargs="?",
         default=1,
         help="Number of images to create per run",
     )
     parser.add_argument(
-        "--n_iter",
+        "--iters",
         type=int,
         nargs="?",
         default=1,
         help="Number of times to run pipeline",
     )
     parser.add_argument(
-        "--H", type=int, nargs="?", default=512, help="Image height in pixels"
+        "--height", type=int, nargs="?", default=512, help="Image height in pixels"
     )
     parser.add_argument(
-        "--W", type=int, nargs="?", default=512, help="Image width in pixels"
+        "--width", type=int, nargs="?", default=512, help="Image width in pixels"
     )
     parser.add_argument(
         "--scale",
@@ -178,7 +178,7 @@ def main():
         "--seed", type=int, nargs="?", default=0, help="RNG seed for repeatability"
     )
     parser.add_argument(
-        "--ddim_steps", type=int, nargs="?", default=50, help="Number of sampling steps"
+        "--steps", type=int, nargs="?", default=50, help="Number of sampling steps"
     )
     parser.add_argument(
         "--attention-slicing",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-diffusers[torch]==0.12.0
+diffusers[torch]==0.12.1
 onnxruntime==1.13.1
 safetensors==0.2.8
 torch==1.13.1+cu117


### PR DESCRIPTION
The big refactor is here:

- Rename and refactor old img2img options
- Add table of renamed options 
- Reorder parts of documentation
- Add table of most popular models
- Update diffusers to 0.12.1
- Fix tests to use downloaded image now that img folder is gone

Renamed options:

| txt2img | stable-diffusion-docker |
|---------|-------------------------|
| `--H` | `--height` |
| `--W` | `--width` |
| `--n_iter` | `--iters` |
| `--n_samples` | `--samples` |
| `--ddim_steps` | `--steps` |

Resolves #49 , resolves #50 .