### PR TITLE
Add instruct-pix2pix pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ To build:
 
 ### Text-to-Image (`txt2img`)
 
+Create an image from a text prompt.
+
 To run:
 
 ```sh
@@ -68,6 +70,8 @@ To run:
 
 ### Image-to-Image (`img2img`)
 
+Create an image from an existing image and a text prompt.
+
 First, copy an image to the `input` folder. Next, to run:
 
 ```sh
@@ -75,6 +79,8 @@ First, copy an image to the `input` folder. Next, to run:
 ```
 
 ### Depth-Guided Diffusion (`depth2img`)
+
+Modify an existing image with its depth map and a text prompt.
 
 First, copy an image to the `input` folder. Next, to run:
 
@@ -85,6 +91,8 @@ First, copy an image to the `input` folder. Next, to run:
 
 ### Instruct Pix2Pix (`pix2pix`)
 
+Modify an existing image with a text prompt.
+
 First, copy an image to the `input` folder. Next, to run:
 
 ```sh
@@ -94,6 +102,8 @@ First, copy an image to the `input` folder. Next, to run:
 
 ### Image Upscaling (`upscale4x`)
 
+Create a high resolution image from an existing image with a text prompt.
+
 First, copy an image to the `input` folder. Next, to run:
 
 ```sh
@@ -102,6 +112,8 @@ First, copy an image to the `input` folder. Next, to run:
 ```
 
 ### Diffusion Inpainting (`inpaint`)
+
+Modify specific areas of an existing image with an image mask and a text prompt.
 
 First, copy an image and an image mask to the `input` folder. White areas of the
 mask will be diffused and black areas will be kept untouched. Next, to run:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ First, copy an image to the `input` folder. Next, to run:
   --image image.png 'A detailed description of the objects to change'
 ```
 
+### Instruct Pix2Pix (`pix2pix`)
+
+First, copy an image to the `input` folder. Next, to run:
+
+```sh
+./build.sh run --model 'timbrooks/instruct-pix2pix' \
+  --image image.png 'A detailed description of the objects to change'
+```
+
 ### Image Upscaling (`upscale4x`)
 
 First, copy an image to the `input` folder. Next, to run:
@@ -128,6 +137,8 @@ Other options:
 * `--half`: use float16 tensors instead of float32 (default `float32`)
 * `--image [IMAGE]`: the input image to use for image-to-image diffusion
 (default `None`)
+* `--image-scale [IMAGE_SCALE]`: how closely the image should follow the
+original image (default `None`)
 * `--mask [MASK]`: the input mask to use for diffusion inpainting (default
 `None`)
 * `--negative-prompt [NEGATIVE_PROMPT]`: the prompt to not render into an image

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The following are the most common options:
 * `--width [WIDTH]`: image width in pixels (default 512, must be divisible by 64)
 * `--iters [ITERS]`: number of times to run pipeline (default 1)
 * `--samples [SAMPLES]`: number of images to create per run (default 1)
-* `--scale [SCALE]`: unconditional guidance scale (default 7.5)
+* `--scale [SCALE]`: how closely the image should follow the prompt (default 7.5)
 * `--scheduler [SCHEDULER]`: override the scheduler used to denoise the image
 (default `None`)
 * `--seed [SEED]`: RNG seed for repeatability (default is a random seed)

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ run() {
 
 tests() {
     BASE_URL="https://raw.githubusercontent.com/fboulnois/repository-assets/main/assets/stable-diffusion-docker"
-    TEST_IMAGE="An_impressionist_painting_of_a_parakeet_eating_spaghetti_in_the_desert_s1.png"
+    TEST_IMAGE="An_impressionist_painting_of_a_parakeet_eating_spaghetti_in_the_desert_full.png"
     curl -sL "${BASE_URL}/${TEST_IMAGE}" > "$PWD/input/${TEST_IMAGE}"
     run --skip --height 512 --width 640 "abstract art"
     run --device cpu --image "${TEST_IMAGE}" --strength 0.6 "abstract art"

--- a/build.sh
+++ b/build.sh
@@ -66,6 +66,12 @@ tests() {
         --xformers-memory-efficient-attention \
         --negative-prompt "bad, ugly, deformed, malformed, mutated, bad anatomy" \
         --prompt "a toucan"
+    run --model "timbrooks/instruct-pix2pix" \
+        --scale 7.0 --image-scale 2.0 \
+        --image "${TEST_IMAGE}" --attention-slicing \
+        --xformers-memory-efficient-attention \
+        --negative-prompt "bad, ugly, deformed, malformed, mutated, bad anatomy" \
+        --prompt "replace the sky with bricks"
     run --model "runwayml/stable-diffusion-v1-5" \
         --samples 2 --iters 2 --seed 42 \
         --scheduler HeunDiscreteScheduler \

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -221,7 +221,7 @@ def main():
         type=float,
         nargs="?",
         default=7.5,
-        help="Classifier free guidance scale",
+        help="How closely the image should follow the prompt",
     )
     parser.add_argument(
         "--scheduler",

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -11,6 +11,7 @@ from diffusers import (
     StableDiffusionPipeline,
     StableDiffusionImg2ImgPipeline,
     StableDiffusionInpaintPipeline,
+    StableDiffusionInstructPix2PixPipeline,
     StableDiffusionUpscalePipeline,
     schedulers,
 )
@@ -38,6 +39,7 @@ def remove_unused_args(p):
         "num_images_per_prompt": p.samples,
         "num_inference_steps": p.steps,
         "guidance_scale": p.scale,
+        "image_guidance_scale": p.image_scale,
         "strength": p.strength,
         "generator": p.generator,
     }
@@ -57,6 +59,7 @@ def stable_diffusion_pipeline(p):
     models = argparse.Namespace(
         **{
             "depth2img": ["stabilityai/stable-diffusion-2-depth"],
+            "pix2pix": ["timbrooks/instruct-pix2pix"],
             "upscalers": ["stabilityai/stable-diffusion-x4-upscaler"],
         }
     )
@@ -65,6 +68,8 @@ def stable_diffusion_pipeline(p):
             p.diffuser = OnnxStableDiffusionImg2ImgPipeline
         elif p.model in models.depth2img:
             p.diffuser = StableDiffusionDepth2ImgPipeline
+        elif p.model in models.pix2pix:
+            p.diffuser = StableDiffusionInstructPix2PixPipeline
         elif p.model in models.upscalers:
             p.diffuser = StableDiffusionUpscalePipeline
         else:
@@ -168,6 +173,12 @@ def main():
         type=str,
         nargs="?",
         help="The input image to use for image-to-image diffusion",
+    )
+    parser.add_argument(
+        "--image-scale",
+        type=float,
+        nargs="?",
+        help="How closely the image should follow the original image",
     )
     parser.add_argument(
         "--iters",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ diffusers[torch]==0.12.1
 onnxruntime==1.14.0
 safetensors==0.2.8
 torch==1.13.1+cu117
-transformers==4.26.0
+transformers==4.26.1
 xformers==0.0.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 diffusers[torch]==0.12.1
-onnxruntime==1.13.1
+onnxruntime==1.14.0
 safetensors==0.2.8
 torch==1.13.1+cu117
 transformers==4.26.0


### PR DESCRIPTION
Adds instruct-pix2pix which allows parts of the image to be modified with the text prompt:

```sh
./build.sh run --model 'timbrooks/instruct-pix2pix' --image image.png 'A detailed description of the part(s) of the image to change'
```

Other changes:

- Use a full sized image for testing
- Update onnxruntime to 1.14.0 and transformers to 4.26.1
- Update `--scale` option description
- Add short description of each pipeline
