### PR TITLE
Split onnx into separate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By default, the pipeline uses the full model and weights which requires a CUDA
 capable GPU with 8GB+ of VRAM. It should take a few seconds to create one image.
 On less powerful GPUs you may need to modify some of the options; see the
 [Examples](#examples) section for more details. If you lack a suitable GPU you
-can set the option `--device cpu` instead.
+can set the options `--device cpu` and `--onnx` instead.
 
 ### Huggingface token
 
@@ -155,6 +155,7 @@ original image (default `None`)
 `None`)
 * `--negative-prompt [NEGATIVE_PROMPT]`: the prompt to not render into an image
 (default `None`)
+* `--onnx`: use the onnx runtime for inference (default is off)
 * `--skip`: skip safety checker (default is the safety checker is on)
 * `--strength [STRENGTH]`: diffusion strength to apply to the input image
 (default 0.75)

--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ tests() {
     TEST_IMAGE="An_impressionist_painting_of_a_parakeet_eating_spaghetti_in_the_desert_full.png"
     curl -sL "${BASE_URL}/${TEST_IMAGE}" > "$PWD/input/${TEST_IMAGE}"
     run --skip --height 512 --width 640 "abstract art"
-    run --device cpu --image "${TEST_IMAGE}" --strength 0.6 "abstract art"
+    run --device cpu --onnx --image "${TEST_IMAGE}" --strength 0.6 "abstract art"
     run --model "stabilityai/stable-diffusion-2" \
         --skip --height 768 --width 768 "abstract art"
     run --model "stabilityai/stable-diffusion-2-1" \

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -49,7 +49,7 @@ def remove_unused_args(p):
 def stable_diffusion_pipeline(p):
     p.dtype = torch.float16 if p.half else torch.float32
 
-    if p.device == "cpu":
+    if p.onnx:
         p.diffuser = OnnxStableDiffusionPipeline
         p.revision = "onnx"
     else:
@@ -63,6 +63,7 @@ def stable_diffusion_pipeline(p):
             "upscalers": ["stabilityai/stable-diffusion-x4-upscaler"],
         }
     )
+
     if p.image is not None:
         if p.revision == "onnx":
             p.diffuser = OnnxStableDiffusionImg2ImgPipeline
@@ -205,6 +206,14 @@ def main():
         type=str,
         nargs="?",
         help="The prompt to not render into an image",
+    )
+    parser.add_argument(
+        "--onnx",
+        type=bool,
+        nargs="?",
+        const=True,
+        default=False,
+        help="Use the onnx runtime for inference",
     )
     parser.add_argument(
         "--prompt", type=str, nargs="?", help="The prompt to render into an image"


### PR DESCRIPTION
Make onnx optional so that `--device cpu` works with `stabilityai/stable-diffusion-2` and `stabilityai/stable-diffusion-2-1`. Older pipelines will continue to work when using the `--onnx` option:

```sh
./build.sh run --device cpu --onnx --half --prompt "abstract art"
```

Resolves #66 