### PR TITLE
Add VAE tiling for ultra-high resolution images

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ The following are the most common options:
 
 Other options:
 
-* `--attention-slicing`: use less memory at the expense of inference speed
-(default is no attention slicing)
+* `--attention-slicing`: use less memory but decrease inference speed (default
+is no attention slicing)
 * `--device [DEVICE]`: the cpu or cuda device to use to render images (default
 `cuda`)
 * `--half`: use float16 tensors instead of float32 (default `float32`)
@@ -161,6 +161,8 @@ original image (default `None`)
 (default 0.75)
 * `--token [TOKEN]`: specify a Huggingface user access token at the command line
 instead of reading it from a file (default is a file)
+* `--vae-tiling`: use less memory when generating ultra-high resolution images
+but massively decrease inference speed (default is no tiling)
 * `--xformers-memory-efficient-attention`: use less memory but require the
 xformers library (default is that xformers is not required)
 

--- a/build.sh
+++ b/build.sh
@@ -72,6 +72,9 @@ tests() {
         --xformers-memory-efficient-attention \
         --negative-prompt "bad, ugly, deformed, malformed, mutated, bad anatomy" \
         --prompt "replace the sky with bricks"
+    run --model "dreamlike-art/dreamlike-diffusion-1.0" \
+        --skip --vae-tiling --xformers-memory-efficient-attention \
+        --height 1024 --width 1024 "abstract art"
     run --model "runwayml/stable-diffusion-v1-5" \
         --samples 2 --iters 2 --seed 42 \
         --scheduler HeunDiscreteScheduler \

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -121,6 +121,9 @@ def stable_diffusion_pipeline(p):
     if p.xformers_memory_efficient_attention:
         pipeline.enable_xformers_memory_efficient_attention()
 
+    if p.vae_tiling:
+        pipeline.vae.enable_tiling()
+
     p.pipeline = pipeline
 
     print("loaded models after:", iso_date_time(), flush=True)
@@ -248,6 +251,11 @@ def main():
     )
     parser.add_argument(
         "--token", type=str, nargs="?", help="Huggingface user access token"
+    )
+    parser.add_argument(
+        "--vae-tiling",
+        action="store_true",
+        help="Use less memory when generating ultra-high resolution images",
     )
     parser.add_argument(
         "--width", type=int, nargs="?", default=512, help="Image width in pixels"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-diffusers[torch]==0.13.1
-onnxruntime==1.14.0
-safetensors==0.2.8
+diffusers[torch]==0.14.0
+onnxruntime==1.14.1
+safetensors==0.3.0
 torch==1.13.1+cu117
 transformers==4.26.1
 xformers==0.0.16


### PR DESCRIPTION
Adds VAE tiling which uses less memory when generating ultra-high resolution images but which also massively decreases inference speed:

```
./build.sh run --height 2048 --width 4096 \
  --skip --vae-tiling --xformers-memory-efficient-attention \
  --prompt "abstract art"
```

Other changes:

- Update `diffusers` to 0.14.0, `onnxruntime` to 1.14.1, and `safetensors` to 0.3.0
- Add test for VAE tiling