### PR TITLE
Add stable unCLIP variations and VAE slicing

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,10 @@ original image (default `None`)
 (default 0.75)
 * `--token [TOKEN]`: specify a Huggingface user access token at the command line
 instead of reading it from a file (default is a file)
-* `--vae-tiling`: use less memory when generating ultra-high resolution images
-but massively decrease inference speed (default is no tiling)
+* `--vae-slicing`: use less memory when creating large batches of images
+(default is no vae slicing)
+* `--vae-tiling`: use less memory when creating ultra-high resolution images but
+massively decrease inference speed (default is no vae tiling)
 * `--xformers-memory-efficient-attention`: use less memory but require the
 xformers library (default is that xformers is not required)
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ First, copy an image to the `input` folder. Next, to run:
   --image image.png 'A detailed description of the objects to change'
 ```
 
+### Stable UnCLIP Variations (`unclip`)
+
+Create different versions of an image with a text prompt.
+
+First, copy an image to the `input` folder. Next, to run:
+
+```sh
+./build.sh run --model 'stabilityai/stable-diffusion-2-1-unclip-small' \
+  --image image.png 'A detailed description of the image'
+```
+
 ### Image Upscaling (`upscale4x`)
 
 Create a high resolution image from an existing image with a text prompt.

--- a/build.sh
+++ b/build.sh
@@ -66,6 +66,8 @@ tests() {
         --xformers-memory-efficient-attention \
         --negative-prompt "bad, ugly, deformed, malformed, mutated, bad anatomy" \
         --prompt "a toucan"
+    run --model "stabilityai/stable-diffusion-2-1-unclip" --image "${TEST_IMAGE}" \
+        --prompt "An impressionist painting of a parakeet eating spaghetti in the desert"
     run --model "timbrooks/instruct-pix2pix" \
         --scale 7.0 --image-scale 2.0 \
         --image "${TEST_IMAGE}" --attention-slicing \

--- a/build.sh
+++ b/build.sh
@@ -78,7 +78,7 @@ tests() {
     run --model "runwayml/stable-diffusion-v1-5" \
         --samples 2 --iters 2 --seed 42 \
         --scheduler HeunDiscreteScheduler \
-        --scale 7.5 --steps 80 --attention-slicing \
+        --scale 7.5 --steps 80 --vae-slicing --attention-slicing \
         --half --skip --negative-prompt "red roses" \
         --prompt "bouquet of roses"
 }

--- a/build.sh
+++ b/build.sh
@@ -50,7 +50,7 @@ tests() {
     BASE_URL="https://raw.githubusercontent.com/fboulnois/repository-assets/main/assets/stable-diffusion-docker"
     TEST_IMAGE="An_impressionist_painting_of_a_parakeet_eating_spaghetti_in_the_desert_full.png"
     curl -sL "${BASE_URL}/${TEST_IMAGE}" > "$PWD/input/${TEST_IMAGE}"
-    run --skip --height 512 --width 640 "abstract art"
+    run --half --skip --height 512 --width 640 "abstract art \\/:*?\"<>|"
     run --device cpu --onnx --image "${TEST_IMAGE}" --strength 0.6 "abstract art"
     run --model "stabilityai/stable-diffusion-2" \
         --skip --height 768 --width 768 "abstract art"

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -100,7 +100,8 @@ def stable_diffusion_pipeline(p):
     print("load pipeline start:", iso_date_time(), flush=True)
 
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=FutureWarning)
+        for c in [UserWarning, FutureWarning]:
+            warnings.filterwarnings("ignore", category=c)
         pipeline = p.diffuser.from_pretrained(
             p.model,
             torch_dtype=p.dtype,

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -122,8 +122,11 @@ def stable_diffusion_pipeline(p):
     if p.xformers_memory_efficient_attention:
         pipeline.enable_xformers_memory_efficient_attention()
 
+    if p.vae_slicing:
+        pipeline.enable_vae_slicing()
+
     if p.vae_tiling:
-        pipeline.vae.enable_tiling()
+        pipeline.enable_vae_tiling()
 
     p.pipeline = pipeline
 
@@ -259,9 +262,14 @@ def main():
         "--token", type=str, nargs="?", help="Huggingface user access token"
     )
     parser.add_argument(
+        "--vae-slicing",
+        action="store_true",
+        help="Use less memory when creating large batches of images",
+    )
+    parser.add_argument(
         "--vae-tiling",
         action="store_true",
-        help="Use less memory when generating ultra-high resolution images",
+        help="Use less memory when creating ultra-high resolution images",
     )
     parser.add_argument(
         "--width", type=int, nargs="?", default=512, help="Image width in pixels"

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import argparse, datetime, inspect, os, warnings
+import argparse, datetime, inspect, os, re, warnings
 import numpy as np
 import torch
 from PIL import Image
@@ -132,7 +132,12 @@ def stable_diffusion_pipeline(p):
 
 
 def stable_diffusion_inference(p):
-    prefix = p.prompt.replace(" ", "_")[:170]
+    prefix = (
+        re.sub(r"[\\/:*?\"<>|]", "", p.prompt)
+        .replace(" ", "_")
+        .encode("utf-8")[:170]
+        .decode("utf-8", "ignore")
+    )
     for j in range(p.iters):
         result = p.pipeline(**remove_unused_args(p))
 

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -13,6 +13,7 @@ from diffusers import (
     StableDiffusionInpaintPipeline,
     StableDiffusionInstructPix2PixPipeline,
     StableDiffusionUpscalePipeline,
+    StableUnCLIPImg2ImgPipeline,
     schedulers,
 )
 
@@ -60,6 +61,10 @@ def stable_diffusion_pipeline(p):
         **{
             "depth2img": ["stabilityai/stable-diffusion-2-depth"],
             "pix2pix": ["timbrooks/instruct-pix2pix"],
+            "unclip": [
+                "stabilityai/stable-diffusion-2-1-unclip",
+                "stabilityai/stable-diffusion-2-1-unclip-small",
+            ],
             "upscalers": ["stabilityai/stable-diffusion-x4-upscaler"],
         }
     )
@@ -71,6 +76,8 @@ def stable_diffusion_pipeline(p):
             p.diffuser = StableDiffusionDepth2ImgPipeline
         elif p.model in models.pix2pix:
             p.diffuser = StableDiffusionInstructPix2PixPipeline
+        elif p.model in models.unclip:
+            p.diffuser = StableUnCLIPImg2ImgPipeline
         elif p.model in models.upscalers:
             p.diffuser = StableDiffusionUpscalePipeline
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-diffusers[torch]==0.14.0
+diffusers[torch]==0.15.0
 onnxruntime==1.14.1
 safetensors==0.3.0
-torch==1.13.1+cu117
-transformers==4.26.1
-xformers==0.0.16
+torch==2.0.0+cu117
+transformers==4.28.1
+xformers==0.0.17


### PR DESCRIPTION
Adds stable unCLIP variations which creates different versions of an existing image with a text prompt:

```sh
./build.sh run --model 'stabilityai/stable-diffusion-2-1-unclip-small' \
  --image parakeet_eating_spaghetti.png \
  --prompt 'An impressionist painting of a parakeet eating spaghetti in the desert'
```

Also adds VAE slicing to lower memory use when generating batches of images:

```
./build.sh run --samples 2 --iters 2 \
  --skip --vae-slicing --xformers-memory-efficient-attention \
  --prompt "abstract art"
```

Other changes:

- Update `torch` to 2.0.0, `transformers` to 4.28.1, `diffusers` to 0.15.0, and `xformers` to 0.0.17
- Fix issue with invalid filenames and add test (resolves #77)
- Temporarily suppress UserWarning due to deprecated parameters in `diffusers` pipelines
- Add tests for VAE slicing and unCLIP variations
- Add VAE slicing option and an example for unCLIP variations to docs