### PR TITLE
feat: add --output filename option

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ original image (default `None`)
 * `--negative-prompt [NEGATIVE_PROMPT]`: the prompt to not render into an image
 (default `None`)
 * `--onnx`: use the onnx runtime for inference (default is off)
+* `--output [OUTPUT]`: the filename to output to (default is automatically generated)
 * `--skip`: skip safety checker (default is the safety checker is on)
 * `--strength [STRENGTH]`: diffusion strength to apply to the input image
 (default 0.75)


### PR DESCRIPTION
Hi @fboulnois.  I hope you don't mind me making this pull request.  I wanted to give this a go to see if I could do it,  and thought you might find it useful as well.

### Synopsis

This pull request adds a new `--output xxx` option,  to allow the user to ***specify a filename to output to***.

I wanted to let the caller specify this.  This way,  when programmatically calling `./build.sh run`,  the calling script knows exactly which output file to look for.

### Usage

``` bash
./build.sh run 'a person riding a bicycle on a bridge' --output my_file.png
```

### Notes

- the user is only allowed to specify `.png` filenames (an exception is raised otherwise)
- a default name is still generated when needed
- ***small differences to the existing behaviour***:
  - the output filename/s are shown for the user to see. e.g. `output file: my_file.png`
  - the iteration is still added to the filename (i.e. `__n_1`, `__n_2`, etc) regardless of whether the user specified their own filename or not,  *but only when creating more than one image* (i.e. `--iters` > 1 or `--samples` > 1)
- `README.md` has been updated