### PR TITLE
Add stable diffusion XL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.40.0](https://github.com/fboulnois/stable-diffusion-docker/compare/v1.39.0...v1.40.0) - 2023-08-23
+
+### Added
+
+* Add test for stable diffusion xl
+* Add stable diffusion xl
+* Update diffusers to 0.20.0
+
 ## [v1.39.0](https://github.com/fboulnois/stable-diffusion-docker/compare/v1.38.0...v1.39.0) - 2023-07-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Many popular models are supported out-of-the-box:
 | [Stable Diffusion 1.5](https://huggingface.co/runwayml/stable-diffusion-v1-5) | `'runwayml/stable-diffusion-v1-5'` |
 | [Stable Diffusion 2.0](https://huggingface.co/stabilityai/stable-diffusion-2) | `'stabilityai/stable-diffusion-2'` |
 | [Stable Diffusion 2.1](https://huggingface.co/stabilityai/stable-diffusion-2-1) | `'stabilityai/stable-diffusion-2-1'` |
+| [Stable Diffusion XL](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0) | `'stabilityai/stable-diffusion-xl-base-1.0'` |
 | [OpenJourney 1.0](https://huggingface.co/prompthero/openjourney) | `'prompthero/openjourney'` |
 | [Dreamlike Diffusion 1.0](https://huggingface.co/dreamlike-art/dreamlike-diffusion-1.0) | `'dreamlike-art/dreamlike-diffusion-1.0'` |
 | [and more!](https://huggingface.co/models?other=stable-diffusion&sort=likes) | ... |

--- a/build.sh
+++ b/build.sh
@@ -56,6 +56,9 @@ tests() {
         --skip --height 768 --width 768 "abstract art"
     run --model "stabilityai/stable-diffusion-2-1" \
         --skip --height 768 --width 768 "abstract art"
+    run --model "stabilityai/stable-diffusion-xl-base-1.0" \
+        --skip --xformers-memory-efficient-attention \
+        --prompt "abstract art"
     run --model "stabilityai/stable-diffusion-x4-upscaler" \
         --image "${TEST_IMAGE}" --half --attention-slicing \
         --xformers-memory-efficient-attention \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-diffusers[torch]==0.18.2
+diffusers[torch]==0.20.0
 onnxruntime==1.15.1
-safetensors==0.3.1
+safetensors==0.3.2
 torch==2.0.1+cu117
 transformers==4.31.0
-xformers==0.0.20
+xformers==0.0.21


### PR DESCRIPTION
Add [stable diffusion XL](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0) as a supported model:

```
./build.sh run --model "stabilityai/stable-diffusion-xl-base-1.0" \
  --skip --xformers-memory-efficient-attention \
  --prompt "abstract art"
```

Additionally:

* Refactor and simplify the internals of `stable-diffusion-docker`
* Use new AutoPipeline feature when available
* Update `diffusers` to 0.20.0, `xformers` to 0.0.21, and `safetensors` to 0.3.2
* Add a test for stable diffusion XL