### PR TITLE
fix space issue when downloading models

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
+**/huggingface
 **/input
 **/output
+**/tmp

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/huggingface
 /input
 /output
+/tmp
 token.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,11 @@ RUN mkdir -p /home/huggingface/.cache/huggingface \
   && mkdir -p /home/huggingface/input \
   && mkdir -p /home/huggingface/output
 
+VOLUME [ "/home/huggingface/.cache/huggingface" ]
+VOLUME [ "/home/huggingface/input" ]
+VOLUME [ "/home/huggingface/output" ]
+VOLUME [ "/tmp" ]
+
 COPY docker-entrypoint.py /usr/local/bin
 COPY token.txt /home/huggingface
 

--- a/build.sh
+++ b/build.sh
@@ -25,9 +25,10 @@ clean() {
 
 dev() {
     docker run --rm --gpus=all --entrypoint=sh \
-        -v huggingface:/home/huggingface/.cache/huggingface \
+        -v "$PWD"/huggingface:/home/huggingface/.cache/huggingface \
         -v "$PWD"/input:/home/huggingface/input \
         -v "$PWD"/output:/home/huggingface/output \
+        -v "$PWD"/tmp:/tmp \
         -it "$CWD"
 }
 
@@ -40,9 +41,10 @@ pull() {
 run() {
     set_gpu_arg "$@"
     docker run --rm ${GPU_ARG} \
-        -v huggingface:/home/huggingface/.cache/huggingface \
+        -v "$PWD"/huggingface:/home/huggingface/.cache/huggingface \
         -v "$PWD"/input:/home/huggingface/input \
         -v "$PWD"/output:/home/huggingface/output \
+        -v "$PWD"/tmp:/tmp \
         "$CWD" "$@"
 }
 
@@ -88,7 +90,7 @@ tests() {
         --prompt "bouquet of roses"
 }
 
-mkdir -p input output
+mkdir -p huggingface input output tmp
 case ${1:-build} in
     build) build ;;
     clean) clean ;;


### PR DESCRIPTION
It may happen that, depending on the model, huggingface-hub creates temporary file chunks before saving the model into the cache. The side effect is that the container `/tmp` can become full and an error is issued `not space left on device`.
With this change, `/tmp` is mapped to a local directory with hopefully more space available.
I also took the opportunity to update `.dockerignore` and `.gitignore` to add the cache directory `huggingface` and this new temp dir...