### PR TITLE
map token rather than copying into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,5 @@ RUN mkdir -p /home/huggingface/.cache/huggingface \
   && mkdir -p /home/huggingface/output
 
 COPY docker-entrypoint.py /usr/local/bin
-COPY token.txt /home/huggingface
 
 ENTRYPOINT [ "docker-entrypoint.py" ]

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,14 @@ set_gpu_arg() {
     GPU_ARG="--gpus=all"
 }
 
+check_token() {
+    [ -r ${PWD}/token.txt ] || {
+        echo "ERROR: no token found"
+        echo "you need to create a user access token in your Huggingface account. Save the user access token in a file called token.txt in current directory."
+        exit 1
+    }
+}
+
 build() {
     docker build . --tag "$CWD"
 }
@@ -24,10 +32,12 @@ clean() {
 }
 
 dev() {
+    check_token
     docker run --rm --gpus=all --entrypoint=sh \
         -v huggingface:/home/huggingface/.cache/huggingface \
         -v "$PWD"/input:/home/huggingface/input \
         -v "$PWD"/output:/home/huggingface/output \
+        -v "$PWD"/token.txt:/home/huggingface/token.txt \
         -it "$CWD"
 }
 
@@ -38,11 +48,13 @@ pull() {
 }
 
 run() {
+    check_token
     set_gpu_arg "$@"
     docker run --rm ${GPU_ARG} \
         -v huggingface:/home/huggingface/.cache/huggingface \
         -v "$PWD"/input:/home/huggingface/input \
         -v "$PWD"/output:/home/huggingface/output \
+        -v "$PWD"/token.txt:/home/huggingface/token.txt \
         "$CWD" "$@"
 }
 


### PR DESCRIPTION
With this change the `token.txt` is mapped when running the container rather than being copied into the image.
This gives the option to use a very generic image.