### PR TITLE
Clean up contributing sections and add Ruff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,15 +8,15 @@ This project accepts community contributions. In order to contribute, please:
 
 ## Coding Style
 
-Please make sure to run [Black](https://black.readthedocs.io/en/stable/index.html)
-and [Flake8](https://flake8.pycqa.org/en/latest/) before submitting a PR.
+Please make sure to run [Ruff](https://github.com/astral-sh/ruff) before
+submitting a PR.
 
 ## Developer Certificate of Origin
 
 By contributing a PR to this project you agree to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
 
-In short, you agree that you can make the contribution and that the project has
-the right to distribute your contribution under the terms of the project's
+This ensures that you can make the contribution and that the project has the
+right to distribute your contribution under the terms of the project's
 [LICENSE](LICENSE). The PR itself is a sign-off of your agreement to the DCO.
 
 ## Submission

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ so these are not part of the official release.
 The images are saved as PNGs in the `output` folder using the prompt text. The
 `build.sh` script creates and mounts this folder as a volume in the container.
 
-## Contribution
+## Contributing
 
 See the [CONTRIBUTING.md](CONTRIBUTING.md) file for more details. In short,
 follow the style guidelines, agree to the Developer Certificate of Origin, and

--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
-import argparse, datetime, inspect, os, re, warnings
+import argparse
+import datetime
+import inspect
+import os
+import re
+import warnings
+
 import numpy as np
 import torch
 from PIL import Image
@@ -290,6 +296,7 @@ def parse_args():
         args.prompt = args.prompt0
 
     return args
+
 
 def main():
     args = parse_args()


### PR DESCRIPTION
Use `ruff` as the Python linter, apply it to the codebase, and clean up wording in contributing sections.